### PR TITLE
Bump actions/setup-node to 7.0.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
         shell: pwsh
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Supersedes Dependabot PR #2 after the adjacent checkout update caused a merge conflict.

- pins `actions/setup-node` 7.0.0 to the immutable Dependabot-provided SHA
- retains `actions/checkout` 7.0.1
- requires the full Validation workflow before merge