### PR TITLE
Add batched identity risk exposure report

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy a safe, report-only-first baseline of nine Microsoft Entra Conditional Ac
 This template helps an administrator:
 
 - establish a report-only baseline for nine risk policies;
-- review tenant-specific impact before enabling enforcement;
+- estimate 30-day tenant-specific impact before enabling enforcement;
 - deliver optional administrator and user notifications; and
 - migrate from legacy Identity Protection risk policies with rollback coverage.
 
@@ -29,7 +29,7 @@ Install:
 Install-PSResource Microsoft.Graph.Authentication -Scope CurrentUser
 ```
 
-Use a Conditional Access Administrator or Security Administrator who can deploy to the selected subscription and consent to the Microsoft Graph permissions requested by the chosen features. Notification modes also create Azure role assignments and therefore need permission to assign roles. Review [identity and permissions](docs/identity-and-permissions.md) before production use. Entra ID P2 or Entra Suite licensing is required for risk-based Conditional Access.
+Use a Security Administrator, or a Conditional Access Administrator with the read roles documented in [identity and permissions](docs/identity-and-permissions.md), who can deploy to the selected subscription and consent to the Microsoft Graph permissions requested by the chosen features. Notification modes also create Azure role assignments and therefore need permission to assign roles. Entra ID P2 or Entra Suite licensing is required for risk-based Conditional Access.
 
 ### Deploy
 
@@ -39,7 +39,7 @@ azd init -t nathanmcnulty/azd-risk-based-ca && azd up
 
 The first run uses report-only policy state, walks through the required tenant and exclusion settings, shows the plan before changes, and uses the normal Azure and Microsoft Graph browser sign-in. Rerun `azd up` to continue or reconcile an existing environment. Device-code authentication is not supported.
 
-After deployment, review the plan and applied report, inspect sign-in logs and Conditional Access What If results, and verify the emergency access path. Follow [operations and cleanup](docs/operations-and-cleanup.md) for verification and teardown.
+Before deployment changes are applied, the hook writes a fast risk-exposure summary with 30-day risky sign-in event counts and a current actionable risky-user snapshot. The counts are tenant-wide upper bounds rather than a replay of policy targeting. After deployment, review that summary, the linked Identity Protection reports, the plan and applied report, Conditional Access What If results, and the emergency access path. Follow [operations and cleanup](docs/operations-and-cleanup.md) for verification and teardown.
 
 ## What this deploys
 
@@ -47,6 +47,7 @@ After deployment, review the plan and applied report, inspect sign-in logs and C
 - Optional Teams delivery through a tenant-local managed connection or an existing Teams Workflow webhook.
 - Optional Graph risk-detection polling through an Azure Functions Flex Consumption app, or Log Analytics scheduled alerting when the workspace already receives the required risk tables.
 - Local deployment reports and ownership-aware state for reconciliation and cleanup.
+- A read-only, batched risk-exposure summary based on 30-day sign-in risk and current risky-user counts.
 
 The default is report-only policy state and no notification backend. See [configuration](docs/configuration.md) to choose notification and enforcement settings.
 
@@ -55,6 +56,7 @@ The default is report-only policy state and no notification backend. See [config
 | Guide | Purpose |
 | --- | --- |
 | [Policies and safety](docs/policies-and-safety.md) | Policy behavior, report-only defaults, exclusions, adoption, and enablement gates |
+| [Historical impact](docs/historical-impact.md) | Batched Graph risk counts, Identity Protection links, policy mapping, and limitations |
 | [Identity and permissions](docs/identity-and-permissions.md) | Azure roles, Graph consent, authentication, and emergency access expectations |
 | [Configuration](docs/configuration.md) | Environment values, notification choices, and common deployment examples |
 | [Notifications](docs/notifications.md) | Graph polling, Log Analytics, Teams delivery, consent, and testing |

--- a/azd-gui.json
+++ b/azd-gui.json
@@ -12,7 +12,7 @@
   "connections": [
     { "id": "azd", "name": "Azure Developer CLI", "required": true, "reason": "Manage environment values and optional Azure notification resources." },
     { "id": "azureCli", "name": "Azure CLI", "required": true, "scopes": ["https://management.azure.com/.default"], "reason": "Resolve the selected subscription and tenant." },
-    { "id": "graphPowerShell", "name": "Microsoft Graph PowerShell", "required": true, "scopes": ["Policy.Read.All", "Policy.ReadWrite.ConditionalAccess", "Group.Read.All", "RoleManagement.Read.Directory", "User.Read"], "reason": "Plan and reconcile Conditional Access. The normal WAM/browser connection requests administrator consent when these privileged delegated scopes have not been granted." }
+    { "id": "graphPowerShell", "name": "Microsoft Graph PowerShell", "required": true, "scopes": ["AuditLog.Read.All", "Group.Read.All", "IdentityRiskyUser.Read.All", "Policy.Read.All", "Policy.ReadWrite.ConditionalAccess", "RoleManagement.Read.Directory", "User.Read"], "reason": "Count historical sign-in risk events and current risky users, then plan and reconcile Conditional Access. The normal WAM/browser connection requests administrator consent when these privileged delegated scopes have not been granted." }
   ],
   "configuration": {
     "groups": [

--- a/docs/historical-impact.md
+++ b/docs/historical-impact.md
@@ -1,0 +1,55 @@
+# Historical risk exposure
+
+Before Conditional Access changes are applied, preprovision sends one read-only Microsoft Graph batch containing five filtered count requests. The result is saved to `reports/azd-risk-ca-historical-impact.json` and summarized in the terminal. No sign-in, risky-user, user-history, role, or group collections are downloaded for this report.
+
+The batch counts:
+
+- high-risk user sign-in events during the previous 30 days;
+- low/medium-risk user sign-in events during the previous 30 days;
+- medium/high-risk user sign-in events during the previous 30 days;
+- currently actionable high-risk users; and
+- currently actionable medium/high-risk users.
+
+Sign-in requests filter `riskLevelDuringSignIn`, the risk available when Conditional Access evaluated the sign-in, and explicitly include interactive and noninteractive user events. Risky-user requests use the Identity Protection portal predicate: `atRisk` or `confirmedCompromised`, not deleted, and at the applicable policy risk level. Graph can execute up to 20 requests in a JSON batch; this report uses five independent GET subrequests.
+
+## What the counts mean
+
+Sign-in measurements count events, not distinct users. One person can produce several events. Risky-user measurements count the current actionable risky-user records and are not a historical list of everyone who reached that risk level during the reporting period.
+
+All measurements are tenant-wide upper bounds. They intentionally do not enumerate identities to apply current administrator roles, group membership, internal/guest classification, or Conditional Access exclusions. Consequently, the report does not say that a specific number of users would have been blocked, prompted for MFA, or required to remediate. It shows the volume at the risk thresholds used by the generated policies and directs administrators to Identity Protection for investigation.
+
+| Policy | Aggregate signal |
+| --- | --- |
+| `Admin-SignInRisk-High-Block` | Tenant-wide high-risk sign-in events during the previous 30 days |
+| `Admin-SignInRisk-LowMedium-RequireMFA` | Tenant-wide low/medium-risk sign-in events during the previous 30 days |
+| `Admin-UserRisk-MediumHigh-Block` | Current tenant-wide medium/high risky users |
+| `User-SignInRisk-MediumHigh-RequireMFA` | Tenant-wide medium/high-risk sign-in events during the previous 30 days |
+| `User-UserRisk-High-RiskRemediation` | Current tenant-wide high-risk users |
+
+The two security-info registration policies and two device-registration policies remain unevaluable. Sign-in and risky-user reports do not reliably identify those user-action attempts, and ordinary risk events must not be treated as registration attempts.
+
+## Investigate affected identities
+
+The terminal and JSON report always include these administrator links:
+
+- [Risky users report](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/RiskyUsers)
+- [Risky sign-ins report](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/RiskySignIns)
+
+Use the portal reports to select the relevant risk levels, review the affected identities, and account for current administrator targeting and exclusions. Rerun `azd up` to refresh the aggregate exposure immediately before enabling enforcement, then use report-only Conditional Access results and What If alongside these reports.
+
+## Availability and API boundary
+
+The filtered `/$count` behavior is live-validated for the beta sign-in and risky-user collections, but those collection API pages do not document it as a supported query option. Every subresponse is therefore validated independently. A rejected or malformed count is recorded as unavailable and is never replaced with zero. If the outer batch fails, all five measurements are unavailable while the Identity Protection links remain in the report and terminal output.
+
+The Graph connection requests `AuditLog.Read.All` and `IdentityRiskyUser.Read.All` in addition to the policy, role, group, and signed-in-user scopes used by deployment planning. A Security Administrator can read both data sets. A Conditional Access Administrator needs additional supported read roles such as Reports Reader for sign-ins and Security Reader for risky users.
+
+This design does not assume Log Analytics, diagnostic settings, or exported retention. Organizations that already export `SigninLogs` and Identity Protection tables can perform richer server-side distinct-user analysis independently without adding that dependency to this template.
+
+## Microsoft references
+
+- [Combine Graph requests with JSON batching](https://learn.microsoft.com/graph/json-batching)
+- [List sign-ins](https://learn.microsoft.com/graph/api/signin-list)
+- [Sign-in risk properties](https://learn.microsoft.com/graph/api/resources/signin)
+- [List risky users](https://learn.microsoft.com/graph/api/riskyuser-list)
+- [Identity Protection risk reports](https://learn.microsoft.com/entra/id-protection/concept-risk-reports)
+- [Microsoft Entra data retention](https://learn.microsoft.com/entra/identity/monitoring-health/reference-reports-data-retention)

--- a/docs/identity-and-permissions.md
+++ b/docs/identity-and-permissions.md
@@ -6,9 +6,9 @@ The operator needs Azure CLI access to the target subscription and permission to
 
 ## Microsoft Graph access
 
-The baseline delegated scopes are `Policy.Read.All`, `Policy.ReadWrite.ConditionalAccess`, `Group.Read.All`, `RoleManagement.Read.Directory`, and `User.Read`. Notification mode `graph` additionally requests `Application.Read.All` and `AppRoleAssignment.ReadWrite.All` to grant the Function identity `IdentityRiskEvent.Read.All`. Optional scopes are not requested for other modes.
+The baseline delegated scopes are `Policy.Read.All`, `Policy.ReadWrite.ConditionalAccess`, `Group.Read.All`, `RoleManagement.Read.Directory`, `User.Read`, `AuditLog.Read.All`, and `IdentityRiskyUser.Read.All`. The last two count historical sign-in risk events and current actionable risky users for the risk-exposure summary; the deployment does not enumerate identities for that report. Notification mode `graph` additionally requests `Application.Read.All` and `AppRoleAssignment.ReadWrite.All` to grant the Function identity `IdentityRiskEvent.Read.All`. Notification-only scopes are not requested for other modes.
 
-Conditional Access policy and authentication-strength writes support Conditional Access Administrator or Security Administrator as the least-privileged built-in roles. Graph notification mode also assigns a Microsoft Graph application role to the Function service principal; the operator therefore needs a role supported for app-role assignments, such as Privileged Role Administrator, Application Administrator, or Cloud Application Administrator.
+Conditional Access policy and authentication-strength writes support Conditional Access Administrator or Security Administrator as the least-privileged built-in roles. Security Administrator can also read the sign-in and risky-user APIs used by the exposure summary. A Conditional Access Administrator needs an additional supported read role: Reports Reader for sign-ins and Security Reader for risky users. Graph notification mode also assigns a Microsoft Graph application role to the Function service principal; the operator therefore needs a role supported for app-role assignments, such as Privileged Role Administrator, Application Administrator, or Cloud Application Administrator.
 
 The hooks reuse a valid cached Graph context when its tenant, account, cloud, and scopes match. Otherwise Microsoft Graph PowerShell uses the normal operating-system broker or browser flow. A read-only `/me` probe confirms that the current process has a usable token before planning.
 
@@ -25,3 +25,6 @@ Runtime notification resources use managed identity where applicable. Callback U
 - [Create a Conditional Access policy](https://learn.microsoft.com/graph/api/conditionalaccessroot-post-policies)
 - [Create an authentication strength policy](https://learn.microsoft.com/graph/api/authenticationstrengthroot-post-policies)
 - [Grant an app role to a service principal](https://learn.microsoft.com/graph/api/serviceprincipal-post-approleassignments)
+- [Combine Graph requests with JSON batching](https://learn.microsoft.com/graph/json-batching)
+- [List sign-ins](https://learn.microsoft.com/graph/api/signin-list)
+- [List risky users](https://learn.microsoft.com/graph/api/riskyuser-list)

--- a/docs/operations-and-cleanup.md
+++ b/docs/operations-and-cleanup.md
@@ -4,7 +4,7 @@
 
 Review `reports/azd-risk-ca-plan.json` before enablement and `reports/azd-risk-ca-applied.json` after deployment. Confirm all nine policies in the Conditional Access portal, run What If tests, review sign-in logs, and validate the emergency access path.
 
-Postprovision rereads every managed policy by recorded object ID and compares normalized desired request shape with actual Graph state. It writes `reports/azd-risk-ca-applied.json` and fails on any difference. Policy application is compensating-transactional: a later Graph write restores objects changed during that run in reverse order. If compensation is incomplete, the checkpoint remains for explicit cleanup and the deployment reports affected actions.
+Preprovision writes `reports/azd-risk-ca-historical-impact.json` with batched Graph counts and Identity Protection investigation links. Unavailable count endpoints are recorded as unavailable rather than zero and do not block the report-only plan. Postprovision rereads every managed policy by recorded object ID and compares normalized desired request shape with actual Graph state. It writes `reports/azd-risk-ca-applied.json` and fails on any difference. Policy application is compensating-transactional: a later Graph write restores objects changed during that run in reverse order. If compensation is incomplete, the checkpoint remains for explicit cleanup and the deployment reports affected actions.
 
 ## Rerun and troubleshoot
 

--- a/docs/policies-and-safety.md
+++ b/docs/policies-and-safety.md
@@ -22,7 +22,7 @@ Device registration never uses Block. Set `AZD_CA_USE_TAP_AUTH_STRENGTH=true` to
 
 ## Safe rollout
 
-Provisioning defaults every policy to `enabledForReportingButNotEnforced`. Review the generated plan and applied report, inspect sign-in logs across a normal access cycle, and use Conditional Access What If for administrators, internal users, guests, registration actions, and emergency accounts. Only then set `AZD_CA_POLICY_STATE=enabled`; the hook requires an exact tenant-ID confirmation.
+Provisioning defaults every policy to `enabledForReportingButNotEnforced`. Review the generated plan, the [risk-exposure summary](historical-impact.md), its linked Identity Protection reports, and the applied report; inspect sign-in logs across a normal access cycle; and use Conditional Access What If for administrators, internal users, guests, registration actions, and emergency accounts. Only then set `AZD_CA_POLICY_STATE=enabled`; the hook requires an exact tenant-ID confirmation.
 
 An existing emergency-access group is preferred. If it is omitted, the signed-in operator is excluded as a temporary single-user failsafe. A same-name object is never treated as owned automatically; set `AZD_CA_ADOPT_EXISTING=true` only after reviewing it.
 

--- a/scripts/AzdRiskCa.Authentication.psm1
+++ b/scripts/AzdRiskCa.Authentication.psm1
@@ -2,7 +2,10 @@ Set-StrictMode -Version Latest
 
 function Get-AzdRiskCaGraphPermissionScope {
     [CmdletBinding()] param([ValidateSet('none','graph','logAnalytics')][string]$NotificationMode = 'none')
-    $scopes = @('Policy.Read.All','Policy.ReadWrite.ConditionalAccess','Group.Read.All','RoleManagement.Read.Directory','User.Read')
+    $scopes = @(
+        'AuditLog.Read.All','Group.Read.All','IdentityRiskyUser.Read.All','Policy.Read.All',
+        'Policy.ReadWrite.ConditionalAccess','RoleManagement.Read.Directory','User.Read'
+    )
     if ($NotificationMode -eq 'graph') { $scopes += @('Application.Read.All','AppRoleAssignment.ReadWrite.All') }
     return @($scopes | Sort-Object -Unique)
 }

--- a/scripts/AzdRiskCa.Impact.psm1
+++ b/scripts/AzdRiskCa.Impact.psm1
@@ -1,0 +1,192 @@
+Set-StrictMode -Version Latest
+
+$script:GraphBetaBatchUri = 'https://graph.microsoft.com/beta/$batch'
+$script:RiskyUsersPortalUri = 'https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/RiskyUsers'
+$script:RiskySignInsPortalUri = 'https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/RiskySignIns'
+$script:EvaluatedPolicies = @(
+    [pscustomobject]@{ name='Admin-SignInRisk-High-Block'; metricId='signInHigh'; note='Tenant-wide high-risk sign-in events; administrator targeting and exclusions are not applied.' }
+    [pscustomobject]@{ name='Admin-SignInRisk-LowMedium-RequireMFA'; metricId='signInLowMedium'; note='Tenant-wide low- or medium-risk sign-in events; administrator targeting and exclusions are not applied.' }
+    [pscustomobject]@{ name='Admin-UserRisk-MediumHigh-Block'; metricId='riskyUserMediumHighCurrent'; note='Current tenant-wide medium/high risky users; administrator targeting and exclusions are not applied.' }
+    [pscustomobject]@{ name='User-SignInRisk-MediumHigh-RequireMFA'; metricId='signInMediumHigh'; note='Tenant-wide medium/high-risk sign-in events; Conditional Access targeting and exclusions are not applied.' }
+    [pscustomobject]@{ name='User-UserRisk-High-RiskRemediation'; metricId='riskyUserHighCurrent'; note='Current tenant-wide high-risk users; internal-user targeting and exclusions are not applied.' }
+)
+$script:UnevaluatedPolicyNames = @(
+    'User-UserRisk-Any-Block-SecurityInfoRegistration'
+    'User-SignInRisk-Any-Block-SecurityInfoRegistration'
+    'User-UserRisk-Any-RequireStrongAuth-DeviceRegistration'
+    'User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration'
+)
+
+function Get-AzdRiskCaImpactProperty {
+    param([AllowNull()][object]$Object, [Parameter(Mandatory)][string]$Name)
+    if ($null -eq $Object) { return $null }
+    if ($Object -is [System.Collections.IDictionary]) { return $Object[$Name] }
+    $property = $Object.PSObject.Properties[$Name]
+    if ($property) { return $property.Value }
+    return $null
+}
+
+function Get-AzdRiskCaIdentityProtectionLinks {
+    [CmdletBinding()] param()
+    return [pscustomobject]@{
+        riskyUsers = $script:RiskyUsersPortalUri
+        riskySignIns = $script:RiskySignInsPortalUri
+    }
+}
+
+function New-AzdRiskCaImpactCountUrl {
+    param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string]$Filter)
+    return "/$Path/`$count?`$filter=$([uri]::EscapeDataString($Filter))"
+}
+
+function New-AzdRiskCaImpactBatchRequest {
+    param([Parameter(Mandatory)][DateTimeOffset]$Start, [Parameter(Mandatory)][DateTimeOffset]$End)
+    $startText = $Start.UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $endText = $End.UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $dateFilter = "createdDateTime ge $startText and createdDateTime lt $endText"
+    $userSignIns = "(signInEventTypes/any(t: t eq 'interactiveUser') or signInEventTypes/any(t: t eq 'nonInteractiveUser'))"
+    $currentRisk = "(riskState eq 'atRisk' or riskState eq 'confirmedCompromised') and isDeleted eq false"
+    $definitions = @(
+        [pscustomobject]@{ id='signInHigh'; path='auditLogs/signIns'; filter="$dateFilter and riskLevelDuringSignIn eq 'high' and $userSignIns"; kind='historicalSignInEvents'; label='High-risk sign-in events during the reporting period' }
+        [pscustomobject]@{ id='signInLowMedium'; path='auditLogs/signIns'; filter="$dateFilter and (riskLevelDuringSignIn eq 'low' or riskLevelDuringSignIn eq 'medium') and $userSignIns"; kind='historicalSignInEvents'; label='Low- or medium-risk sign-in events during the reporting period' }
+        [pscustomobject]@{ id='signInMediumHigh'; path='auditLogs/signIns'; filter="$dateFilter and (riskLevelDuringSignIn eq 'medium' or riskLevelDuringSignIn eq 'high') and $userSignIns"; kind='historicalSignInEvents'; label='Medium- or high-risk sign-in events during the reporting period' }
+        [pscustomobject]@{ id='riskyUserHighCurrent'; path='identityProtection/riskyUsers'; filter="$currentRisk and riskLevel eq 'high'"; kind='currentRiskyUsers'; label='Currently actionable high-risk users' }
+        [pscustomobject]@{ id='riskyUserMediumHighCurrent'; path='identityProtection/riskyUsers'; filter="$currentRisk and (riskLevel eq 'medium' or riskLevel eq 'high')"; kind='currentRiskyUsers'; label='Currently actionable medium- or high-risk users' }
+    )
+    $requests = foreach ($definition in $definitions) {
+        [ordered]@{
+            id = $definition.id
+            method = 'GET'
+            url = New-AzdRiskCaImpactCountUrl $definition.path $definition.filter
+            headers = @{ ConsistencyLevel='eventual' }
+        }
+    }
+    return [pscustomobject]@{ definitions=$definitions; body=[ordered]@{ requests=@($requests) } }
+}
+
+function New-AzdRiskCaUnavailableMetric {
+    param([Parameter(Mandatory)][object]$Definition, [Parameter(Mandatory)][string]$Status)
+    return [pscustomobject]@{
+        id = $Definition.id
+        label = $Definition.label
+        kind = $Definition.kind
+        available = $false
+        count = $null
+        status = $Status
+    }
+}
+
+function ConvertFrom-AzdRiskCaImpactBatchResponse {
+    param([Parameter(Mandatory)][object]$BatchResponse, [Parameter(Mandatory)][object[]]$Definitions)
+    $responses = @(Get-AzdRiskCaImpactProperty $BatchResponse 'responses')
+    $metrics = [System.Collections.Generic.List[object]]::new()
+    foreach ($definition in $Definitions) {
+        $response = @($responses | Where-Object { [string]$_.id -eq [string]$definition.id }) | Select-Object -First 1
+        if (-not $response) {
+            $metrics.Add((New-AzdRiskCaUnavailableMetric $definition 'missingResponse'))
+            continue
+        }
+        $statusCode = [int](Get-AzdRiskCaImpactProperty $response 'status')
+        $count = 0L
+        $body = Get-AzdRiskCaImpactProperty $response 'body'
+        if ($statusCode -ne 200 -or -not [long]::TryParse([string]$body, [ref]$count)) {
+            $metrics.Add((New-AzdRiskCaUnavailableMetric $definition "http$statusCode"))
+            continue
+        }
+        $metrics.Add([pscustomobject]@{
+            id = $definition.id
+            label = $definition.label
+            kind = $definition.kind
+            available = $true
+            count = $count
+            status = 'available'
+        })
+    }
+    return @($metrics)
+}
+
+function Get-AzdRiskCaMetricDisplayValue {
+    param([Parameter(Mandatory)][object]$Metric)
+    if ($Metric.available) { return [string]$Metric.count }
+    return 'unavailable'
+}
+
+function Get-AzdRiskCaHistoricalImpact {
+    [CmdletBinding()] param(
+        [Parameter(Mandatory)][object]$Plan,
+        [ValidateRange(1,30)][int]$Days = 30,
+        [DateTimeOffset]$AsOf = [DateTimeOffset]::UtcNow
+    )
+    $end = $AsOf.ToUniversalTime()
+    $start = $end.AddDays(-$Days)
+    $batch = New-AzdRiskCaImpactBatchRequest $start $end
+    try {
+        $response = Invoke-AzdRiskCaGraphRequest POST $script:GraphBetaBatchUri $batch.body
+        $metrics = @(ConvertFrom-AzdRiskCaImpactBatchResponse $response @($batch.definitions))
+        $batchStatus = 'completed'
+    } catch {
+        $metrics = @($batch.definitions | ForEach-Object { New-AzdRiskCaUnavailableMetric $_ 'batchRequestFailed' })
+        $batchStatus = 'failed'
+    }
+
+    $metricById = @{}
+    foreach ($metric in $metrics) { $metricById[$metric.id] = $metric }
+    $policies = [System.Collections.Generic.List[object]]::new()
+    foreach ($mapping in $script:EvaluatedPolicies) {
+        $metric = $metricById[$mapping.metricId]
+        $policies.Add([pscustomobject]@{
+            name = $mapping.name
+            evaluable = $true
+            metricId = $mapping.metricId
+            available = $metric.available
+            count = $metric.count
+            unit = if ($metric.kind -eq 'historicalSignInEvents') { 'signInEvents' } else { 'users' }
+            targetingApplied = $false
+            note = $mapping.note
+        })
+    }
+    foreach ($name in $script:UnevaluatedPolicyNames) {
+        $policies.Add([pscustomobject]@{
+            name = $name
+            evaluable = $false
+            metricId = $null
+            available = $false
+            count = $null
+            unit = $null
+            targetingApplied = $false
+            note = 'Graph sign-in and risky-user reports do not identify security-info or device-registration attempts reliably.'
+        })
+    }
+
+    $highSignIns = Get-AzdRiskCaMetricDisplayValue $metricById.signInHigh
+    $lowMediumSignIns = Get-AzdRiskCaMetricDisplayValue $metricById.signInLowMedium
+    $mediumHighSignIns = Get-AzdRiskCaMetricDisplayValue $metricById.signInMediumHigh
+    $highUsers = Get-AzdRiskCaMetricDisplayValue $metricById.riskyUserHighCurrent
+    $mediumHighUsers = Get-AzdRiskCaMetricDisplayValue $metricById.riskyUserMediumHighCurrent
+    $summary = "Previous $Days days: $highSignIns high-risk, $lowMediumSignIns low/medium-risk, and $mediumHighSignIns medium/high-risk user sign-in events. Currently: $highUsers high-risk and $mediumHighUsers medium/high-risk users. Counts are tenant-wide and do not apply Conditional Access targeting or exclusions."
+
+    return [pscustomobject]@{
+        schemaVersion = '2.0'
+        generatedAt = $end.ToString('o')
+        tenantId = [string]$Plan.tenantId
+        period = [pscustomobject]@{ days=$Days; start=$start.ToString('o'); end=$end.ToString('o') }
+        estimate = [pscustomobject]@{ summary=$summary; measurements=$metrics }
+        policies = @($policies)
+        dataQuality = [pscustomobject]@{
+            batchStatus = $batchStatus
+            availableMeasurements = @($metrics | Where-Object available).Count
+            unavailableMeasurements = @($metrics | Where-Object available -eq $false).Count
+            countEndpointContract = 'The filtered /$count behavior is live-validated but not documented for these collection APIs; unavailable counts are never replaced with zero.'
+        }
+        investigate = Get-AzdRiskCaIdentityProtectionLinks
+        assumptions = @(
+            'Sign-in measurements count events, not distinct users.'
+            'Risky-user measurements are a current actionable snapshot, not a historical count.'
+            'All measurements are tenant-wide upper bounds before current policy targeting, administrator membership, internal-user classification, and exclusions.'
+            'Interactive and noninteractive user sign-ins are included; workload identity event types are excluded.'
+            'Security-info registration and device-registration policies are intentionally not estimated.'
+        )
+    }
+}
+
+Export-ModuleMember -Function *

--- a/scripts/Pre-Provision.ps1
+++ b/scripts/Pre-Provision.ps1
@@ -4,6 +4,7 @@ Import-Module (Join-Path $PSScriptRoot 'AzdRiskCa.Common.psm1') -Force
 Import-Module (Join-Path $PSScriptRoot 'AzdRiskCa.Wizard.psm1') -Force
 Import-Module (Join-Path $PSScriptRoot 'AzdRiskCa.Authentication.psm1') -Force
 Import-Module (Join-Path $PSScriptRoot 'AzdRiskCa.Graph.psm1') -Force
+Import-Module (Join-Path $PSScriptRoot 'AzdRiskCa.Impact.psm1') -Force
 
 Import-AzdEnvironment
 Invoke-AzdRiskCaFirstRunWizard | Out-Null
@@ -50,6 +51,18 @@ Connect-AzdRiskCaGraph ([guid]$tenantId) $configuration | Out-Null
 $plan=New-AzdRiskCaPlan $configuration (Get-AzdRiskCaState)
 $reportPath=Join-Path (Split-Path -Parent $PSScriptRoot) 'reports/azd-risk-ca-plan.json'
 Save-AzdRiskCaJson $plan $reportPath
+$impactReportPath=Join-Path (Split-Path -Parent $PSScriptRoot) 'reports/azd-risk-ca-historical-impact.json'
+try {
+    $impact=Get-AzdRiskCaHistoricalImpact $plan
+    Save-AzdRiskCaJson $impact $impactReportPath
+    Write-Host $impact.estimate.summary
+    Write-Host "Historical impact report: $impactReportPath"
+} catch {
+    Write-Warning "Historical impact analysis was unavailable and did not block the Conditional Access plan. $($_.Exception.Message)"
+}
+$identityProtectionLinks=Get-AzdRiskCaIdentityProtectionLinks
+Write-Host "Risky users report: $($identityProtectionLinks.riskyUsers)"
+Write-Host "Risky sign-ins report: $($identityProtectionLinks.riskySignIns)"
 
 Write-Host "Conditional Access plan for tenant ${tenantId}: $(@($plan.policies | Where-Object action -eq 'create').Count) create, $(@($plan.policies | Where-Object action -eq 'update').Count) update, $(@($plan.policies | Where-Object action -eq 'none').Count) unchanged."
 foreach ($warning in $plan.warnings) { Write-Warning $warning }

--- a/tests/Authentication.Tests.ps1
+++ b/tests/Authentication.Tests.ps1
@@ -1,6 +1,8 @@
 BeforeAll { Import-Module (Join-Path $PSScriptRoot '../scripts/AzdRiskCa.Authentication.psm1') -Force }
 Describe 'Least-privilege delegated scopes' {
-    It 'uses the five base permissions including operator fallback resolution' { (Get-AzdRiskCaGraphPermissionScope none) | Should -Be @('Group.Read.All','Policy.Read.All','Policy.ReadWrite.ConditionalAccess','RoleManagement.Read.Directory','User.Read') }
+    It 'includes the read scopes required for historical impact and operator fallback resolution' {
+        (Get-AzdRiskCaGraphPermissionScope none) | Should -Be @('AuditLog.Read.All','Group.Read.All','IdentityRiskyUser.Read.All','Policy.Read.All','Policy.ReadWrite.ConditionalAccess','RoleManagement.Read.Directory','User.Read')
+    }
     It 'requests app assignment permissions only for Graph polling' { Get-AzdRiskCaGraphPermissionScope graph | Should -Contain 'AppRoleAssignment.ReadWrite.All'; Get-AzdRiskCaGraphPermissionScope none | Should -Not -Contain 'AppRoleAssignment.ReadWrite.All'; Get-AzdRiskCaGraphPermissionScope logAnalytics | Should -Not -Contain 'Application.Read.All' }
 }
 

--- a/tests/Documentation.Tests.ps1
+++ b/tests/Documentation.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Administrator documentation and deployment packaging' {
     It 'links every focused administrator guide' {
         foreach ($path in @(
             'docs/policies-and-safety.md', 'docs/identity-and-permissions.md',
-            'docs/configuration.md', 'docs/notifications.md',
+            'docs/configuration.md', 'docs/historical-impact.md', 'docs/notifications.md',
             'docs/legacy-migration.md', 'docs/operations-and-cleanup.md',
             'docs/development.md', 'docs/agent-assisted-deployment.md')) {
             (Test-Path (Join-Path $script:root $path)) | Should -BeTrue

--- a/tests/Impact.Tests.ps1
+++ b/tests/Impact.Tests.ps1
@@ -1,0 +1,102 @@
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '../scripts/AzdRiskCa.Graph.psm1') -Force
+    Import-Module (Join-Path $PSScriptRoot '../scripts/AzdRiskCa.Impact.psm1') -Force
+    $script:start=[DateTimeOffset]'2026-07-29T00:00:00Z'
+    $script:end=[DateTimeOffset]'2026-08-28T00:00:00Z'
+    $script:metricIds=@('signInHigh','signInLowMedium','signInMediumHigh','riskyUserHighCurrent','riskyUserMediumHighCurrent')
+}
+
+Describe 'Microsoft Graph aggregate risk batch' {
+    It 'builds five filtered count requests in one batch' {
+        $batch=New-AzdRiskCaImpactBatchRequest $script:start $script:end
+        @($batch.body.requests).Count | Should -Be 5
+        @($batch.body.requests.id) | Should -Be $script:metricIds
+        foreach($request in $batch.body.requests){
+            $request.method | Should -Be 'GET'
+            $request.headers.ConsistencyLevel | Should -Be 'eventual'
+            $request.url | Should -Match '/\$count\?\$filter='
+        }
+        $signInUrls=@($batch.body.requests | Where-Object id -like 'signIn*' | ForEach-Object { [uri]::UnescapeDataString($_.url) })
+        foreach($url in $signInUrls){
+            $url | Should -Match '^/auditLogs/signIns/\$count\?\$filter='
+            $url | Should -Match 'createdDateTime ge 2026-07-29T00:00:00Z'
+            $url | Should -Match 'createdDateTime lt 2026-08-28T00:00:00Z'
+            $url | Should -Match ([regex]::Escape("signInEventTypes/any(t: t eq 'interactiveUser')"))
+            $url | Should -Match ([regex]::Escape("signInEventTypes/any(t: t eq 'nonInteractiveUser')"))
+        }
+        $riskyUserUrls=@($batch.body.requests | Where-Object id -like 'riskyUser*' | ForEach-Object { [uri]::UnescapeDataString($_.url) })
+        foreach($url in $riskyUserUrls){
+            $url | Should -Match '^/identityProtection/riskyUsers/\$count\?\$filter='
+            $url | Should -Match "riskState eq 'atRisk' or riskState eq 'confirmedCompromised'"
+            $url | Should -Match 'isDeleted eq false'
+        }
+    }
+
+    It 'returns event and current-user counts without enumerating identities' {
+        Mock Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Impact {
+            [pscustomobject]@{responses=@(
+                [pscustomobject]@{id='signInHigh';status=200;body='2'},
+                [pscustomobject]@{id='signInLowMedium';status=200;body='7'},
+                [pscustomobject]@{id='signInMediumHigh';status=200;body='5'},
+                [pscustomobject]@{id='riskyUserHighCurrent';status=200;body='3'},
+                [pscustomobject]@{id='riskyUserMediumHighCurrent';status=200;body='11'}
+            )}
+        }
+        $result=Get-AzdRiskCaHistoricalImpact ([pscustomobject]@{tenantId='tenant'}) -AsOf $script:end
+        $result.schemaVersion | Should -Be '2.0'
+        $result.period.days | Should -Be 30
+        $result.estimate.summary | Should -Match '2 high-risk, 7 low/medium-risk, and 5 medium/high-risk user sign-in events'
+        $result.estimate.summary | Should -Match '3 high-risk and 11 medium/high-risk users'
+        $result.dataQuality.availableMeasurements | Should -Be 5
+        $result.dataQuality.unavailableMeasurements | Should -Be 0
+        ($result.estimate.measurements | Where-Object id -eq 'signInMediumHigh').count | Should -Be 5
+        ($result.policies | Where-Object name -eq 'User-SignInRisk-MediumHigh-RequireMFA').unit | Should -Be 'signInEvents'
+        ($result.policies | Where-Object name -eq 'User-UserRisk-High-RiskRemediation').unit | Should -Be 'users'
+        @($result.policies | Where-Object targetingApplied).Count | Should -Be 0
+        $result.investigate.riskyUsers | Should -Be 'https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/RiskyUsers'
+        $result.investigate.riskySignIns | Should -Be 'https://entra.microsoft.com/#view/Microsoft_AAD_IAM/IdentityProtectionMenuBlade/~/RiskySignIns'
+        Assert-MockCalled Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Impact -Times 1 -ParameterFilter {
+            $Method -eq 'POST' -and $Uri -eq 'https://graph.microsoft.com/beta/$batch' -and @($Body.requests).Count -eq 5
+        }
+    }
+
+    It 'marks a failed count unavailable instead of substituting zero' {
+        Mock Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Impact {
+            [pscustomobject]@{responses=@(
+                [pscustomobject]@{id='signInHigh';status=400;body=[pscustomobject]@{error='unsupported'}},
+                [pscustomobject]@{id='signInLowMedium';status=200;body='0'},
+                [pscustomobject]@{id='signInMediumHigh';status=200;body='0'},
+                [pscustomobject]@{id='riskyUserHighCurrent';status=200;body='0'},
+                [pscustomobject]@{id='riskyUserMediumHighCurrent';status=200;body='0'}
+            )}
+        }
+        $result=Get-AzdRiskCaHistoricalImpact ([pscustomobject]@{tenantId='tenant'}) -AsOf $script:end
+        $failed=$result.estimate.measurements | Where-Object id -eq 'signInHigh'
+        $failed.available | Should -BeFalse
+        $failed.count | Should -BeNullOrEmpty
+        $failed.status | Should -Be 'http400'
+        $result.estimate.summary | Should -Match 'unavailable high-risk, 0 low/medium-risk'
+        $result.dataQuality.unavailableMeasurements | Should -Be 1
+    }
+
+    It 'returns links and unavailable metrics when the outer batch request fails' {
+        Mock Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Impact { throw 'batch unavailable' }
+        $result=Get-AzdRiskCaHistoricalImpact ([pscustomobject]@{tenantId='tenant'}) -AsOf $script:end
+        $result.dataQuality.batchStatus | Should -Be 'failed'
+        $result.dataQuality.availableMeasurements | Should -Be 0
+        $result.dataQuality.unavailableMeasurements | Should -Be 5
+        @($result.estimate.measurements | Where-Object { $null -ne $_.count }).Count | Should -Be 0
+        $result.investigate.riskyUsers | Should -Match 'IdentityProtectionMenuBlade/~/RiskyUsers$'
+    }
+
+    It 'marks the four registration policies unevaluable' {
+        Mock Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Impact { throw 'batch unavailable' }
+        $result=Get-AzdRiskCaHistoricalImpact ([pscustomobject]@{tenantId='tenant'}) -AsOf $script:end
+        $unevaluated=@($result.policies | Where-Object evaluable -eq $false)
+        $unevaluated.Count | Should -Be 4
+        foreach($policy in $unevaluated){
+            $policy.count | Should -BeNullOrEmpty
+            $policy.note | Should -Match 'registration'
+        }
+    }
+}

--- a/tests/Manifest.Tests.ps1
+++ b/tests/Manifest.Tests.ps1
@@ -15,6 +15,9 @@ Describe 'Azure Deployment Studio manifest' {
         $connection=$script:manifest.connections | Where-Object id -eq 'graphPowerShell'
         $connection.scopes | Should -Contain 'Policy.ReadWrite.ConditionalAccess'
         $connection.scopes | Should -Contain 'RoleManagement.Read.Directory'
+        $connection.scopes | Should -Contain 'AuditLog.Read.All'
+        $connection.scopes | Should -Contain 'IdentityRiskyUser.Read.All'
+        $connection.scopes | Should -Not -Contain 'User.Read.All'
         $connection.scopes | Should -Not -Contain 'Application.Read.All'
         $connection.scopes | Should -Not -Contain 'AppRoleAssignment.ReadWrite.All'
     }


### PR DESCRIPTION
## Summary
- replace per-user risk-history reconstruction with one beta Graph batch containing five filtered count requests
- report 30-day risky sign-in events and the current actionable risky-user snapshot as tenant-wide upper bounds
- preserve unavailable counts as unavailable, add direct Identity Protection investigation links, and remove the unnecessary `User.Read.All` scope

## Validation
- `Invoke-Pester ./tests -CI` (87 passed)
- PowerShell parser and PSScriptAnalyzer error checks
- `az bicep build --file infra/main.bicep --stdout`
- `npm ci && npm test` in `src/risk-notification-poller` (10 passed)
- read-only Share My Labs live proof: all five batch measurements returned in 1.63 seconds; generated report contained no UPN or user-principal-name fields