### PR TITLE
Retry post-deployment policy validation

### DIFF
--- a/scripts/AzdRiskCa.Graph.psm1
+++ b/scripts/AzdRiskCa.Graph.psm1
@@ -361,14 +361,28 @@ function Invoke-AzdRiskCaApply {
 function Test-AzdRiskCaAppliedState {
     [CmdletBinding()] param([Parameter(Mandatory)][object]$Plan, [Parameter(Mandatory)][object]$State)
     $failures=[System.Collections.Generic.List[string]]::new()
-    foreach ($policy in @($Plan.policies)) {
-        $record=Get-AzdRiskCaProperty $State.policies $policy.displayName
-        try { $actual=Invoke-AzdRiskCaGraphRequest GET (Get-AzdRiskCaPolicyUri $policy.body ([string]$record.id)) } catch { $failures.Add("$($policy.displayName): could not re-read") ; continue }
-        $desired=$policy.body | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100
-        $desiredStrength=Get-AzdRiskCaProperty $desired.grantControls 'authenticationStrength'
-        if ($desiredStrength -and $desiredStrength.id -eq '__CREATED_TAP_STRENGTH__') { $desiredStrength.id=$State.authenticationStrength.id }
-        if (-not (Test-AzdRiskCaEquivalent $desired $actual)) { $failures.Add("$($policy.displayName): desired and actual differ") }
+    $pending=@($Plan.policies)
+    $lastFailure=@{}
+    for ($attempt=1; $attempt -le 6 -and $pending.Count -gt 0; $attempt++) {
+        $retry=[System.Collections.Generic.List[object]]::new()
+        foreach ($policy in $pending) {
+            $record=Get-AzdRiskCaProperty $State.policies $policy.displayName
+            try {
+                $actual=Invoke-AzdRiskCaGraphRequest GET (Get-AzdRiskCaPolicyUri $policy.body ([string]$record.id))
+                $desired=$policy.body | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100
+                $desiredStrength=Get-AzdRiskCaProperty $desired.grantControls 'authenticationStrength'
+                if ($desiredStrength -and $desiredStrength.id -eq '__CREATED_TAP_STRENGTH__') { $desiredStrength.id=$State.authenticationStrength.id }
+                if (Test-AzdRiskCaEquivalent $desired $actual) { $lastFailure.Remove($policy.displayName); continue }
+                $lastFailure[$policy.displayName]="$($policy.displayName): desired and actual differ"
+            } catch {
+                $lastFailure[$policy.displayName]="$($policy.displayName): could not re-read"
+            }
+            $retry.Add($policy)
+        }
+        $pending=@($retry)
+        if ($pending.Count -gt 0 -and $attempt -lt 6) { Start-Sleep -Seconds ($attempt * 2) }
     }
+    foreach ($policy in $pending) { $failures.Add([string]$lastFailure[$policy.displayName]) }
     return [pscustomobject]@{ valid=($failures.Count -eq 0); failures=@($failures) }
 }
 

--- a/tests/Graph.Tests.ps1
+++ b/tests/Graph.Tests.ps1
@@ -7,6 +7,42 @@ BeforeAll {
     $script:config=[pscustomobject]@{PolicyState='reportOnly';AdminCoverageGroupId=$script:coverage}
     $script:bodies=@(Get-AzdRiskCaPolicyBodies $script:config @($script:role) @($script:emergency) $script:strength)
 }
+
+Describe 'Applied-state validation consistency' {
+    BeforeEach {
+        $body=[pscustomobject]@{
+            displayName='Retry policy'
+            state='enabledForReportingButNotEnforced'
+            conditions=[pscustomobject]@{}
+            grantControls=[pscustomobject]@{}
+        }
+        $script:validationPlan=[pscustomobject]@{policies=@([pscustomobject]@{displayName=$body.displayName;body=$body})}
+        $script:validationState=[pscustomobject]@{policies=[pscustomobject]@{'Retry policy'=[pscustomobject]@{id='retry-id'}};authenticationStrength=$null}
+        Mock Start-Sleep -ModuleName AzdRiskCa.Graph {}
+    }
+
+    It 'retries transient policy read failures and then validates the policy' {
+        $script:readAttempts=0
+        Mock Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Graph {
+            $script:readAttempts++
+            if($script:readAttempts -lt 3){throw 'not replicated'}
+            [pscustomobject]@{displayName='Retry policy';state='enabledForReportingButNotEnforced';conditions=[pscustomobject]@{};grantControls=[pscustomobject]@{}}
+        }
+        $result=Test-AzdRiskCaAppliedState $script:validationPlan $script:validationState
+        $result.valid | Should -BeTrue
+        Assert-MockCalled Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Graph -Times 3
+        Assert-MockCalled Start-Sleep -ModuleName AzdRiskCa.Graph -Times 2
+    }
+
+    It 'fails after bounded retries when a policy never becomes readable' {
+        Mock Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Graph { throw 'still unavailable' }
+        $result=Test-AzdRiskCaAppliedState $script:validationPlan $script:validationState
+        $result.valid | Should -BeFalse
+        $result.failures | Should -Contain 'Retry policy: could not re-read'
+        Assert-MockCalled Invoke-AzdRiskCaGraphRequest -ModuleName AzdRiskCa.Graph -Times 6
+        Assert-MockCalled Start-Sleep -ModuleName AzdRiskCa.Graph -Times 5
+    }
+}
 Describe 'Canonical recommended policy payloads' {
     It 'builds exactly the nine approved names' { @($script:bodies).Count | Should -Be 9; @($script:bodies.displayName) | Should -Be @('Admin-SignInRisk-High-Block','Admin-SignInRisk-LowMedium-RequireMFA','Admin-UserRisk-MediumHigh-Block','User-SignInRisk-MediumHigh-RequireMFA','User-UserRisk-High-RiskRemediation','User-UserRisk-Any-Block-SecurityInfoRegistration','User-SignInRisk-Any-Block-SecurityInfoRegistration','User-UserRisk-Any-RequireStrongAuth-DeviceRegistration','User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration') }
     It 'defaults every policy to Graph report-only state' { @($script:bodies | Where-Object state -ne 'enabledForReportingButNotEnforced').Count | Should -Be 0 }


### PR DESCRIPTION
## Summary
- retry only policies that are temporarily unreadable or not yet converged
- bound validation to six passes with increasing backoff
- cover transient recovery and persistent failure behavior

## Validation
- Pester: 89/89
- Function tests: 10/10
- Bicep build passed
- PowerShell parser and ScriptAnalyzer passed
- JSON parsing and git diff checks passed
- Live report-only rerun: 0 create, 0 update, 9 unchanged; applied validation passed
- Live enabled validation: all 9 policies verified enabled
- Ownership-aware teardown and preexisting-policy restoration passed