### PR TITLE
Keep risk policy definitions in template

### DIFF
--- a/docs/policies-and-safety.md
+++ b/docs/policies-and-safety.md
@@ -1,8 +1,6 @@
 # Policies and safety
 
-The template manages nine Conditional Access policies. It normalizes requests before sending them to Microsoft Graph and discovers built-in directory role template IDs in the target tenant.
-
-The same nine normalized policy bodies are published as standalone JSON and a one-shot archive in [nathanmcnulty/nathanmcnulty](https://github.com/nathanmcnulty/nathanmcnulty/tree/main/Entra/conditional-access/risk-policies). This azd template adds tenant-aware role discovery, exclusions, ownership, validation, notifications, and migration safeguards around those policies.
+The template manages nine Conditional Access policies. Their checked-in JSON definitions live in [`policies/`](../policies/), and the deployment reads those files directly. It then materializes tenant-specific Graph request bodies by discovering built-in directory role template IDs and applying the configured groups, exclusions, state, and authentication strength. No policy definition is downloaded from another repository.
 
 ## Policy catalog
 

--- a/policies/Admin-SignInRisk-High-Block.json
+++ b/policies/Admin-SignInRisk-High-Block.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "Admin-SignInRisk-High-Block",
+  "scope": "admin",
+  "riskType": "signIn",
+  "riskLevels": ["high"],
+  "control": "block",
+  "target": "applications"
+}

--- a/policies/Admin-SignInRisk-LowMedium-RequireMFA.json
+++ b/policies/Admin-SignInRisk-LowMedium-RequireMFA.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "Admin-SignInRisk-LowMedium-RequireMFA",
+  "scope": "admin",
+  "riskType": "signIn",
+  "riskLevels": ["low", "medium"],
+  "control": "mfa",
+  "target": "applications"
+}

--- a/policies/Admin-UserRisk-MediumHigh-Block.json
+++ b/policies/Admin-UserRisk-MediumHigh-Block.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "Admin-UserRisk-MediumHigh-Block",
+  "scope": "admin",
+  "riskType": "user",
+  "riskLevels": ["medium", "high"],
+  "control": "block",
+  "target": "applications"
+}

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,7 @@
+# Conditional Access policy definitions
+
+These nine JSON files are the policy source of truth used by the deployment. `manifest.json` fixes their deployment order and prevents an unlisted file from being applied accidentally.
+
+Each definition contains the stable, reviewable policy intent: display name, target scope, risk condition, grant control, and target resource. During deployment, `scripts/AzdRiskCa.Graph.psm1` reads these files and materializes the Microsoft Graph request bodies with tenant-specific built-in role IDs, configured groups and exclusions, report-only or enabled state, and the resolved authentication-strength ID.
+
+The files are deliberately definitions rather than exported tenant objects. They contain no tenant metadata, object IDs, or stale role snapshots, and the deployment does not download policy content from another repository.

--- a/policies/User-SignInRisk-Any-Block-SecurityInfoRegistration.json
+++ b/policies/User-SignInRisk-Any-Block-SecurityInfoRegistration.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "User-SignInRisk-Any-Block-SecurityInfoRegistration",
+  "scope": "all",
+  "riskType": "signIn",
+  "riskLevels": ["low", "medium", "high"],
+  "control": "block",
+  "target": "registerSecurityInfo"
+}

--- a/policies/User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration.json
+++ b/policies/User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration",
+  "scope": "all",
+  "riskType": "signIn",
+  "riskLevels": ["low", "medium", "high"],
+  "control": "strength",
+  "target": "registerDevice"
+}

--- a/policies/User-SignInRisk-MediumHigh-RequireMFA.json
+++ b/policies/User-SignInRisk-MediumHigh-RequireMFA.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "User-SignInRisk-MediumHigh-RequireMFA",
+  "scope": "all",
+  "riskType": "signIn",
+  "riskLevels": ["medium", "high"],
+  "control": "mfa",
+  "target": "applications"
+}

--- a/policies/User-UserRisk-Any-Block-SecurityInfoRegistration.json
+++ b/policies/User-UserRisk-Any-Block-SecurityInfoRegistration.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "User-UserRisk-Any-Block-SecurityInfoRegistration",
+  "scope": "all",
+  "riskType": "user",
+  "riskLevels": ["low", "medium", "high"],
+  "control": "block",
+  "target": "registerSecurityInfo"
+}

--- a/policies/User-UserRisk-Any-RequireStrongAuth-DeviceRegistration.json
+++ b/policies/User-UserRisk-Any-RequireStrongAuth-DeviceRegistration.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "User-UserRisk-Any-RequireStrongAuth-DeviceRegistration",
+  "scope": "all",
+  "riskType": "user",
+  "riskLevels": ["low", "medium", "high"],
+  "control": "strength",
+  "target": "registerDevice"
+}

--- a/policies/User-UserRisk-High-RiskRemediation.json
+++ b/policies/User-UserRisk-High-RiskRemediation.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "User-UserRisk-High-RiskRemediation",
+  "scope": "internal",
+  "riskType": "user",
+  "riskLevels": ["high"],
+  "control": "riskRemediation",
+  "target": "applications"
+}

--- a/policies/manifest.json
+++ b/policies/manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0",
+  "policies": [
+    "Admin-SignInRisk-High-Block.json",
+    "Admin-SignInRisk-LowMedium-RequireMFA.json",
+    "Admin-UserRisk-MediumHigh-Block.json",
+    "User-SignInRisk-MediumHigh-RequireMFA.json",
+    "User-UserRisk-High-RiskRemediation.json",
+    "User-UserRisk-Any-Block-SecurityInfoRegistration.json",
+    "User-SignInRisk-Any-Block-SecurityInfoRegistration.json",
+    "User-UserRisk-Any-RequireStrongAuth-DeviceRegistration.json",
+    "User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration.json"
+  ]
+}

--- a/scripts/AzdRiskCa.Graph.psm1
+++ b/scripts/AzdRiskCa.Graph.psm1
@@ -177,17 +177,28 @@ function Get-AzdRiskCaPolicyBodies {
     [CmdletBinding()] param([Parameter(Mandatory)][object]$Configuration, [Parameter(Mandatory)][string[]]$RoleIds, [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$ExcludeGroups, [Parameter(Mandatory)][string]$AuthenticationStrengthId, [AllowEmptyCollection()][string[]]$ExcludeUsers=@())
     $adminGroups = if ($Configuration.AdminCoverageGroupId) { @($Configuration.AdminCoverageGroupId) } else { @() }
     $common = @{ State=$Configuration.PolicyState; RoleIds=$RoleIds; AdminGroups=$adminGroups; ExcludeGroups=$ExcludeGroups; ExcludeUsers=$ExcludeUsers }
-    return @(
-        New-AzdRiskCaPolicyBody @common -DisplayName 'Admin-SignInRisk-High-Block' -Scope admin -RiskType signIn -RiskLevels high -Control block
-        New-AzdRiskCaPolicyBody @common -DisplayName 'Admin-SignInRisk-LowMedium-RequireMFA' -Scope admin -RiskType signIn -RiskLevels low,medium -Control mfa
-        New-AzdRiskCaPolicyBody @common -DisplayName 'Admin-UserRisk-MediumHigh-Block' -Scope admin -RiskType user -RiskLevels medium,high -Control block
-        New-AzdRiskCaPolicyBody @common -DisplayName 'User-SignInRisk-MediumHigh-RequireMFA' -Scope all -RiskType signIn -RiskLevels medium,high -Control mfa
-        New-AzdRiskCaPolicyBody @common -DisplayName 'User-UserRisk-High-RiskRemediation' -Scope internal -RiskType user -RiskLevels high -Control riskRemediation
-        New-AzdRiskCaPolicyBody @common -DisplayName 'User-UserRisk-Any-Block-SecurityInfoRegistration' -Scope all -RiskType user -RiskLevels low,medium,high -Control block -Target registerSecurityInfo
-        New-AzdRiskCaPolicyBody @common -DisplayName 'User-SignInRisk-Any-Block-SecurityInfoRegistration' -Scope all -RiskType signIn -RiskLevels low,medium,high -Control block -Target registerSecurityInfo
-        New-AzdRiskCaPolicyBody @common -DisplayName 'User-UserRisk-Any-RequireStrongAuth-DeviceRegistration' -Scope all -RiskType user -RiskLevels low,medium,high -Control strength -Target registerDevice -AuthenticationStrengthId $AuthenticationStrengthId
-        New-AzdRiskCaPolicyBody @common -DisplayName 'User-SignInRisk-Any-RequireStrongAuth-DeviceRegistration' -Scope all -RiskType signIn -RiskLevels low,medium,high -Control strength -Target registerDevice -AuthenticationStrengthId $AuthenticationStrengthId
-    )
+    $policyDirectory = Join-Path (Split-Path $PSScriptRoot -Parent) 'policies'
+    $manifestPath = Join-Path $policyDirectory 'manifest.json'
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) { throw "Conditional Access policy manifest was not found at '$manifestPath'." }
+    $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json -Depth 20
+    $files = @($manifest.policies)
+    if ($manifest.schemaVersion -ne '1.0' -or $files.Count -ne 9 -or @($files | Sort-Object -Unique).Count -ne 9) { throw 'Conditional Access policy manifest must contain exactly nine unique policy definitions using schema version 1.0.' }
+
+    return @($files | ForEach-Object {
+        $path = Join-Path $policyDirectory ([string]$_)
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "Conditional Access policy definition was not found at '$path'." }
+        $definition = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json -Depth 20
+        $parameters = @{
+            DisplayName = [string]$definition.displayName
+            Scope = [string]$definition.scope
+            RiskType = [string]$definition.riskType
+            RiskLevels = @($definition.riskLevels)
+            Control = [string]$definition.control
+            Target = [string]$definition.target
+        }
+        if ($parameters.Control -eq 'strength') { $parameters.AuthenticationStrengthId = $AuthenticationStrengthId }
+        New-AzdRiskCaPolicyBody @common @parameters
+    })
 }
 
 function Resolve-AzdRiskCaAuthenticationStrength {

--- a/tests/Documentation.Tests.ps1
+++ b/tests/Documentation.Tests.ps1
@@ -5,6 +5,22 @@ Describe 'Administrator documentation and deployment packaging' {
         $script:notifications = Get-Content (Join-Path $script:root 'scripts/AzdRiskCa.Notifications.psm1') -Raw
         $script:postprovision = Get-Content (Join-Path $script:root 'scripts/Post-Provision.ps1') -Raw
         $script:configurationGuide = Get-Content (Join-Path $script:root 'docs/configuration.md') -Raw
+        $script:policyGuide = Get-Content (Join-Path $script:root 'docs/policies-and-safety.md') -Raw
+    }
+
+    It 'keeps every deployed policy definition in this repository' {
+        $manifest = Get-Content (Join-Path $script:root 'policies/manifest.json') -Raw | ConvertFrom-Json
+        $manifest.schemaVersion | Should -Be '1.0'
+        @($manifest.policies).Count | Should -Be 9
+        @($manifest.policies | Sort-Object -Unique).Count | Should -Be 9
+        foreach ($file in $manifest.policies) {
+            $path = Join-Path $script:root "policies/$file"
+            (Test-Path -LiteralPath $path -PathType Leaf) | Should -BeTrue
+            $definition = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+            $definition.displayName | Should -Be ([IO.Path]::GetFileNameWithoutExtension($file))
+        }
+        $script:policyGuide | Should -Not -Match 'nathanmcnulty/nathanmcnulty'
+        $script:policyGuide | Should -Match 'No policy definition is downloaded from another repository'
     }
 
     It 'keeps the administrator quickstart free of Node prerequisites' {


### PR DESCRIPTION
## Summary
- add nine tenant-neutral Conditional Access policy definitions and an explicit deployment manifest
- load the checked-in definitions when materializing tenant-specific Graph request bodies
- remove the cross-repository policy-content reference and document the local source of truth

## Local validation
- Azure Bicep compilation passed
- PowerShell parsing and PSScriptAnalyzer passed with zero errors
- all repository JSON parsed successfully
- Pester: 90 passed
- Function tests: 10 passed
- old and new generated policy payloads matched byte-for-byte for representative report-only and enabled configurations
- disposable local azd init copied all nine definitions and materialized all nine policy bodies
- git diff --check passed

Hosted Actions may not start because of the account billing issue; this PR is intended to rely on the equivalent local validation above.