### PR TITLE
Clarify risk exposure report retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy a safe, report-only-first baseline of nine Microsoft Entra Conditional Ac
 This template helps an administrator:
 
 - establish a report-only baseline for nine risk policies;
-- estimate 30-day tenant-specific impact before enabling enforcement;
+- estimate tenant risk exposure from the previous 30 days of user sign-ins plus a current risky-user snapshot;
 - deliver optional administrator and user notifications; and
 - migrate from legacy Identity Protection risk policies with rollback coverage.
 
@@ -47,7 +47,7 @@ Before deployment changes are applied, the hook writes a fast risk-exposure summ
 - Optional Teams delivery through a tenant-local managed connection or an existing Teams Workflow webhook.
 - Optional Graph risk-detection polling through an Azure Functions Flex Consumption app, or Log Analytics scheduled alerting when the workspace already receives the required risk tables.
 - Local deployment reports and ownership-aware state for reconciliation and cleanup.
-- A read-only, batched risk-exposure summary based on 30-day sign-in risk and current risky-user counts.
+- A read-only, batched risk-exposure summary based on previous-30-day sign-in risk events and current risky-user counts.
 
 The default is report-only policy state and no notification backend. See [configuration](docs/configuration.md) to choose notification and enforcement settings.
 

--- a/docs/historical-impact.md
+++ b/docs/historical-impact.md
@@ -12,6 +12,8 @@ The batch counts:
 
 Sign-in requests filter `riskLevelDuringSignIn`, the risk available when Conditional Access evaluated the sign-in, and explicitly include interactive and noninteractive user events. Risky-user requests use the Identity Protection portal predicate: `atRisk` or `confirmedCompromised`, not deleted, and at the applicable policy risk level. Graph can execute up to 20 requests in a JSON batch; this report uses five independent GET subrequests.
 
+This is not a crawl of the full Identity Protection reports. The implementation queries `auditLogs/signIns` for the previous 30 days and `identityProtection/riskyUsers` without a date filter, so the latter is a current snapshot. It does not query `riskyUsers/{id}/history` or enumerate identities. Microsoft currently documents default retention of 30 days for Entra audit/sign-in logs, 90 days for P2 risky sign-ins, and no limit for risky users; the 90-day portal availability (and any longer tenant-specific retention) is not automatically used by this report. A 180-day window should not be assumed.
+
 ## What the counts mean
 
 Sign-in measurements count events, not distinct users. One person can produce several events. Risky-user measurements count the current actionable risky-user records and are not a historical list of everyone who reached that risk level during the reporting period.


### PR DESCRIPTION
## Summary
- clarify that the exposure report counts the previous 30 days of sign-in events plus a current risky-user snapshot
- document the exact Graph collections and filters used
- document current Entra retention limits and explain why a 180-day window is not used

## Validation
- Invoke-Pester ./tests -CI
- git diff --check