### PR TITLE
Prepare repository for component governance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+azd-components.lock.json text eol=lf
+scripts/vendor/** text eol=lf
+contracts/notifications/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 azd-components.lock.json text eol=lf
+schemas/azd-components-lock.schema.json text eol=lf
 scripts/vendor/** text eol=lf
 contracts/notifications/** text eol=lf

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,4 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Review dependency changes
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4.8.2
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Validation
+name: Validate template
 
 on:
   pull_request:
@@ -15,42 +15,30 @@ concurrency:
 
 jobs:
   validate:
-    timeout-minutes: 20
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: pwsh
+    name: Validate (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: src/risk-notification-poller/package-lock.json
-      - name: Install Bicep
-        run: az bicep install
-      - name: Compile Bicep
-        run: az bicep build --file infra/main.bicep --stdout | Out-Null
-      - name: Validate PowerShell and JSON
+
+      - name: Install repository validation dependencies
+        shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
-          $parseErrors = @()
-          Get-ChildItem ./scripts -Recurse -File | Where-Object Extension -in '.ps1', '.psm1' | ForEach-Object {
-            $tokens = $null
-            $errors = $null
-            [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors) | Out-Null
-            $parseErrors += @($errors)
-          }
-          if ($parseErrors.Count) { throw ($parseErrors | Out-String) }
-          Get-ChildItem . -Recurse -Filter *.json -File | Where-Object FullName -notlike '*node_modules*' | ForEach-Object {
-            Get-Content $_.FullName -Raw | ConvertFrom-Json -Depth 100 -AsHashtable | Out-Null
-          }
-          $analysis = @(Invoke-ScriptAnalyzer -Path ./scripts -Recurse -Severity Error)
-          if ($analysis.Count) { throw ($analysis | Format-Table | Out-String) }
-      - name: Run PowerShell tests
-        run: |
           Install-Module Pester -RequiredVersion 5.7.1 -Force -Scope CurrentUser
-          Invoke-Pester ./tests -CI
-      - name: Run Function tests
-        working-directory: src/risk-notification-poller
-        run: npm ci && npm test
+          az bicep install --version v0.46.1
+
+      - name: Run offline repository validation
+        shell: pwsh
+        run: ./scripts/Test-Repository.ps1

--- a/azd-components.lock.json
+++ b/azd-components.lock.json
@@ -1,0 +1,5 @@
+{
+  "manifestVersion": "1.0",
+  "baseline": "2026.08",
+  "components": []
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ PowerShell tests and Bicep validation do not authenticate to or mutate a tenant:
 ./scripts/Test-Repository.ps1
 ```
 
-The validation entry point parses and analyzes PowerShell, validates tracked JSON, runs the Pester and Node test suites, audits production npm dependencies, compiles Bicep, and checks the diff for whitespace errors. It requires PowerShell 7, Node.js 22, Azure CLI with Bicep v0.46.1, Pester 5.7.1 or later, and PSScriptAnalyzer 1.25.0 or later. These are contributor/test dependencies and are not administrator deployment prerequisites.
+The validation entry point parses and analyzes PowerShell, validates tracked JSON and the component inventory against its checked-in schema, runs the Pester and Node test suites, audits production npm dependencies, compiles Bicep without restoring external modules, and checks both committed and working changes for whitespace errors. It requires PowerShell 7, Node.js 22, Azure CLI with exactly Bicep v0.46.1, Pester 5.7.1 or later, and PSScriptAnalyzer 1.25.0 or later. These are contributor/test dependencies and are not administrator deployment prerequisites.
 
 The repository-level `azd-components.lock.json` is the inventory used by `azd-reference` governance tooling. An empty `components` array is intentional until this solution adopts exact, versioned component files; do not list similar solution-owned code as an adopted component.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,15 +5,12 @@
 PowerShell tests and Bicep validation do not authenticate to or mutate a tenant:
 
 ```powershell
-az bicep build --file infra/main.bicep --stdout | Out-Null
-Invoke-Pester ./tests -CI
-Push-Location ./src/risk-notification-poller
-npm ci
-npm test
-Pop-Location
+./scripts/Test-Repository.ps1
 ```
 
-Node.js 22 is a contributor/test dependency for the notification poller. It is not an administrator deployment prerequisite.
+The validation entry point parses and analyzes PowerShell, validates tracked JSON, runs the Pester and Node test suites, audits production npm dependencies, compiles Bicep, and checks the diff for whitespace errors. It requires PowerShell 7, Node.js 22, Azure CLI with Bicep v0.46.1, Pester 5.7.1 or later, and PSScriptAnalyzer 1.25.0 or later. These are contributor/test dependencies and are not administrator deployment prerequisites.
+
+The repository-level `azd-components.lock.json` is the inventory used by `azd-reference` governance tooling. An empty `components` array is intentional until this solution adopts exact, versioned component files; do not list similar solution-owned code as an adopted component.
 
 ## Function packaging
 

--- a/schemas/azd-components-lock.schema.json
+++ b/schemas/azd-components-lock.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "azd vendored component lock",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "manifestVersion",
+    "components"
+  ],
+  "properties": {
+    "manifestVersion": {
+      "const": "1.0"
+    },
+    "baseline": {
+      "type": "string",
+      "pattern": "^[0-9]{4}\\.[0-9]{2}(?:\\.[0-9]+)?$"
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/component"
+      }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version",
+        "sourceRepository",
+        "sourceRevision",
+        "files"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]{1,62}[a-z0-9]$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$"
+        },
+        "sourceRepository": {
+          "type": "string",
+          "format": "uri"
+        },
+        "sourceRevision": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "files": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/file"
+          }
+        }
+      }
+    },
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "target",
+        "sha256"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "target": {
+          "$ref": "#/$defs/relativePath"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "relativePath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?![A-Za-z]:)(?!/)(?!\\.{1,2}(?:/|$))(?!.*?/\\.{1,2}(?:/|$))[^\\\\\\u0000-\\u001F]+$"
+    }
+  }
+}

--- a/scripts/Test-Repository.ps1
+++ b/scripts/Test-Repository.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$pollerRoot = Join-Path $repositoryRoot 'src/risk-notification-poller'
+
+function Invoke-CheckedCommand {
+    param(
+        [Parameter(Mandatory)] [string] $Tool,
+        [Parameter(Mandatory)] [scriptblock] $Action
+    )
+
+    & $Action
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Tool failed with exit code $LASTEXITCODE."
+    }
+}
+
+foreach ($command in 'az', 'git', 'node', 'npm') {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+        throw "$command is required for repository validation."
+    }
+}
+
+Write-Host 'Parsing repository PowerShell files.'
+$parseErrors = [System.Collections.Generic.List[object]]::new()
+$powerShellFiles = @(
+    Get-ChildItem -LiteralPath $repositoryRoot -Recurse -File |
+        Where-Object {
+            $_.Extension -in '.ps1', '.psm1', '.psd1' -and
+            $_.FullName -notmatch '[\\/](?:\.azure|node_modules|reports)[\\/]'
+        }
+)
+foreach ($file in $powerShellFiles) {
+    $tokens = $null
+    $fileErrors = $null
+    [void] [System.Management.Automation.Language.Parser]::ParseFile(
+        $file.FullName,
+        [ref] $tokens,
+        [ref] $fileErrors
+    )
+    foreach ($parseError in @($fileErrors)) {
+        $parseErrors.Add($parseError)
+    }
+}
+if ($parseErrors.Count -gt 0) {
+    throw ($parseErrors | Format-List | Out-String)
+}
+
+Write-Host 'Running PSScriptAnalyzer.'
+Import-Module PSScriptAnalyzer -MinimumVersion 1.25.0 -Force -ErrorAction Stop
+$analysis = @(Invoke-ScriptAnalyzer -Path (Join-Path $repositoryRoot 'scripts') -Recurse -Severity Error)
+if ($analysis.Count -gt 0) {
+    throw ($analysis | Format-Table -AutoSize | Out-String)
+}
+
+Write-Host 'Validating tracked JSON and the component inventory.'
+$trackedJson = @(& git -C $repositoryRoot ls-files -- '*.json')
+if ($LASTEXITCODE -ne 0) {
+    throw 'git ls-files failed while locating tracked JSON files.'
+}
+foreach ($relativePath in $trackedJson) {
+    Get-Content -LiteralPath (Join-Path $repositoryRoot $relativePath) -Raw |
+        ConvertFrom-Json -Depth 100 -AsHashtable |
+        Out-Null
+}
+
+$componentLock = Get-Content -LiteralPath (Join-Path $repositoryRoot 'azd-components.lock.json') -Raw |
+    ConvertFrom-Json -Depth 100
+if ($componentLock.manifestVersion -ne '1.0') {
+    throw 'azd-components.lock.json must use manifestVersion 1.0.'
+}
+if ($null -eq $componentLock.components) {
+    throw 'azd-components.lock.json must contain a components array.'
+}
+
+Write-Host 'Running repository Pester tests without tenant access.'
+Import-Module Pester -MinimumVersion 5.7.1 -Force -ErrorAction Stop
+Set-StrictMode -Off
+try {
+    $pesterResult = Invoke-Pester -Path (Join-Path $repositoryRoot 'tests') -Output Detailed -PassThru
+}
+finally {
+    Set-StrictMode -Version Latest
+}
+if ($pesterResult.FailedCount -gt 0) {
+    throw "$($pesterResult.FailedCount) Pester test(s) failed."
+}
+
+Write-Host 'Checking and testing the notification poller.'
+Invoke-CheckedCommand -Tool 'npm ci' -Action {
+    & npm ci --ignore-scripts --prefix $pollerRoot
+}
+Invoke-CheckedCommand -Tool 'node --check' -Action {
+    & node --check (Join-Path $pollerRoot 'src/index.js')
+}
+Invoke-CheckedCommand -Tool 'npm test' -Action {
+    & npm test --prefix $pollerRoot
+}
+Invoke-CheckedCommand -Tool 'npm audit' -Action {
+    & npm audit --omit=dev --audit-level=high --prefix $pollerRoot
+}
+
+Write-Host 'Building the root Bicep template to stdout.'
+Invoke-CheckedCommand -Tool 'az bicep version' -Action {
+    & az bicep version | Out-Null
+}
+Invoke-CheckedCommand -Tool 'az bicep build' -Action {
+    & az bicep build --file (Join-Path $repositoryRoot 'infra/main.bicep') --stdout | Out-Null
+}
+
+Write-Host 'Checking the working diff for whitespace errors.'
+Invoke-CheckedCommand -Tool 'git diff --check' -Action {
+    & git -C $repositoryRoot diff --check
+}
+
+Write-Host "Repository validation passed: $($pesterResult.PassedCount) Pester tests plus PowerShell, JSON, Node, npm audit, Bicep, and whitespace checks."

--- a/scripts/Test-Repository.ps1
+++ b/scripts/Test-Repository.ps1
@@ -68,13 +68,11 @@ foreach ($relativePath in $trackedJson) {
         Out-Null
 }
 
-$componentLock = Get-Content -LiteralPath (Join-Path $repositoryRoot 'azd-components.lock.json') -Raw |
-    ConvertFrom-Json -Depth 100
-if ($componentLock.manifestVersion -ne '1.0') {
-    throw 'azd-components.lock.json must use manifestVersion 1.0.'
-}
-if ($null -eq $componentLock.components) {
-    throw 'azd-components.lock.json must contain a components array.'
+$componentLockPath = Join-Path $repositoryRoot 'azd-components.lock.json'
+$componentLockSchemaPath = Join-Path $repositoryRoot 'schemas/azd-components-lock.schema.json'
+$componentLockJson = Get-Content -LiteralPath $componentLockPath -Raw
+if (-not ($componentLockJson | Test-Json -SchemaFile $componentLockSchemaPath -ErrorAction Stop)) {
+    throw 'azd-components.lock.json does not satisfy the checked-in component lock schema.'
 }
 
 Write-Host 'Running repository Pester tests without tenant access.'
@@ -105,16 +103,38 @@ Invoke-CheckedCommand -Tool 'npm audit' -Action {
 }
 
 Write-Host 'Building the root Bicep template to stdout.'
-Invoke-CheckedCommand -Tool 'az bicep version' -Action {
-    & az bicep version | Out-Null
+$bicepVersionOutput = (& az bicep version 2>&1 | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "az bicep version failed with exit code $LASTEXITCODE."
+}
+if ($bicepVersionOutput -notmatch '^Bicep CLI version 0\.46\.1(?:\s|$)') {
+    throw "Bicep CLI v0.46.1 is required; found: $bicepVersionOutput"
 }
 Invoke-CheckedCommand -Tool 'az bicep build' -Action {
-    & az bicep build --file (Join-Path $repositoryRoot 'infra/main.bicep') --stdout | Out-Null
+    & az bicep build --file (Join-Path $repositoryRoot 'infra/main.bicep') --stdout --no-restore | Out-Null
 }
 
-Write-Host 'Checking the working diff for whitespace errors.'
-Invoke-CheckedCommand -Tool 'git diff --check' -Action {
+Write-Host 'Checking committed and working changes for whitespace errors.'
+Invoke-CheckedCommand -Tool 'git show --check HEAD' -Action {
+    & git -C $repositoryRoot show --check --format= HEAD
+}
+Invoke-CheckedCommand -Tool 'git diff --check (working tree)' -Action {
     & git -C $repositoryRoot diff --check
 }
+Invoke-CheckedCommand -Tool 'git diff --cached --check' -Action {
+    & git -C $repositoryRoot diff --cached --check
+}
 
-Write-Host "Repository validation passed: $($pesterResult.PassedCount) Pester tests plus PowerShell, JSON, Node, npm audit, Bicep, and whitespace checks."
+$baseReference = if ($env:GITHUB_BASE_REF) { "origin/$($env:GITHUB_BASE_REF)" } else { 'origin/main' }
+& git -C $repositoryRoot rev-parse --verify --quiet "$baseReference^{commit}" 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0) {
+    $mergeBase = (& git -C $repositoryRoot merge-base HEAD $baseReference).Trim()
+    if ($LASTEXITCODE -ne 0 -or -not $mergeBase) {
+        throw "Unable to determine the merge base with $baseReference."
+    }
+    Invoke-CheckedCommand -Tool "git diff --check $mergeBase..HEAD" -Action {
+        & git -C $repositoryRoot diff --check "$mergeBase..HEAD"
+    }
+}
+
+Write-Host "Repository validation passed: $($pesterResult.PassedCount) Pester tests plus PowerShell, schema-constrained JSON, Node, npm audit, pinned Bicep, and committed/working whitespace checks."

--- a/tests/Governance.Tests.ps1
+++ b/tests/Governance.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Component governance baseline' {
+    BeforeAll {
+        $repositoryRoot = Split-Path -Parent $PSScriptRoot
+        $lockPath = Join-Path $repositoryRoot 'azd-components.lock.json'
+        $schemaPath = Join-Path $repositoryRoot 'schemas/azd-components-lock.schema.json'
+    }
+
+    It 'keeps the component inventory compatible with the checked-in contract' {
+        $lockJson = Get-Content -LiteralPath $lockPath -Raw
+        ($lockJson | Test-Json -SchemaFile $schemaPath -ErrorAction Stop) | Should -BeTrue
+    }
+
+    It 'rejects noncanonical top-level lock properties' {
+        $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json -AsHashtable
+        $lock.unexpectedProperty = $true
+        $invalidJson = $lock | ConvertTo-Json -Depth 100
+
+        { $invalidJson | Test-Json -SchemaFile $schemaPath -ErrorAction Stop } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
- add the repository governance baseline and a schema-valid empty component inventory
- consolidate offline validation behind `scripts/Test-Repository.ps1`
- run the same SHA-pinned validation workflow on Ubuntu and Windows
- document the component lock boundary so similar solution-owned code is not mislabeled as adopted

## Validation
- `./scripts/Test-Repository.ps1`
  - 90 Pester tests passed
  - 10 Node tests passed
  - production npm audit found 0 vulnerabilities
  - PowerShell parsing and PSScriptAnalyzer passed
  - tracked JSON and component lock parsing passed
  - Bicep compilation and `git diff --check` passed
- component lock validated against `azd-reference/schemas/azd-components-lock.schema.json`

## Scope
This PR does not adopt or copy any shared component and does not change deployment behavior. The empty component list is intentional until exact versioned files are adopted through the reference lifecycle.