### PR TITLE
feat: adopt Azure Monitor notifications pilot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 azd-components.lock.json text eol=lf
 schemas/azd-components-lock.schema.json text eol=lf
 scripts/vendor/** text eol=lf
+infra/vendor/** text eol=lf
 contracts/notifications/** text eol=lf

--- a/azd-components.lock.json
+++ b/azd-components.lock.json
@@ -1,5 +1,24 @@
 {
   "manifestVersion": "1.0",
   "baseline": "2026.08",
-  "components": []
+  "components": [
+    {
+      "id": "azure-monitor-scheduled-query-notifications",
+      "version": "0.1.0",
+      "sourceRepository": "https://github.com/nathanmcnulty/azd-reference",
+      "sourceRevision": "3424613b6b1ba38a1af60c2ab9bea9ef973c5bed",
+      "files": [
+        {
+          "source": "components/bicep/azure-monitor-scheduled-query-notifications/logic-app-action-group.bicep",
+          "target": "infra/vendor/Azd.AzureMonitorNotifications/logic-app-action-group.bicep",
+          "sha256": "90b3dc9bc40c87b88052a021b390db8e7fc960dd7776a3f686ae2ee000b880f9"
+        },
+        {
+          "source": "components/bicep/azure-monitor-scheduled-query-notifications/scheduled-query-alert.bicep",
+          "target": "infra/vendor/Azd.AzureMonitorNotifications/scheduled-query-alert.bicep",
+          "sha256": "fbb1ba6a7caf1085cce8d1a0ae69a98270b2f587aab9370f23fee145ac46968e"
+        }
+      ]
+    }
+  ]
 }

--- a/infra/modules/log-analytics-notifications.bicep
+++ b/infra/modules/log-analytics-notifications.bicep
@@ -78,50 +78,39 @@ resource blobRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
     )
   }
 }
-resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
-  name: 'risk-la-${suffix}'
-  location: 'Global'
-  tags: tags
-  properties: {
+module actionGroup '../vendor/Azd.AzureMonitorNotifications/logic-app-action-group.bicep' = {
+  name: 'risk-la-action-group'
+  params: {
+    actionGroupName: 'risk-la-${suffix}'
     groupShortName: 'Entra risk'
-    enabled: true
-    logicAppReceivers: [
-      {
-        name: 'Risk notification workflow'
-        resourceId: workflow.id
-        callbackUrl: listCallbackUrl('${workflow.id}/triggers/manual', '2019-05-01').value
-        useCommonAlertSchema: true
-      }
-    ]
+    logicAppResourceId: workflow.id
+    receiverName: 'Risk notification workflow'
+    logicAppTriggerName: 'manual'
+    tags: tags
   }
 }
-resource alert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
-  name: 'entra-risk-${suffix}'
-  location: workspaceLocation
-  tags: tags
-  properties: {
+
+module alert '../vendor/Azd.AzureMonitorNotifications/scheduled-query-alert.bicep' = {
+  name: 'entra-risk-alert'
+  params: {
+    alertRuleName: 'entra-risk-${suffix}'
+    location: workspaceLocation
+    workspaceResourceId: workspaceResourceId
+    actionGroupResourceId: actionGroup.outputs.actionGroupResourceId
     displayName: 'Microsoft Entra risk detection'
-    description: 'Uses existing RiskyUsers and UserRiskEvents logs; does not create a workspace or require Sentinel.'
+    alertDescription: 'Uses existing RiskyUsers and UserRiskEvents logs; does not create a workspace or require Sentinel.'
+    query: riskQuery
     severity: 2
-    enabled: true
     evaluationFrequency: 'PT5M'
     windowSize: 'PT10M'
-    scopes: [workspaceResourceId]
-    criteria: {
-      allOf: [
-        {
-          query: riskQuery
-          timeAggregation: 'Count'
-          operator: 'GreaterThan'
-          threshold: 0
-          failingPeriods: { numberOfEvaluationPeriods: 1, minFailingPeriodsToAlert: 1 }
-          dimensions: [
-            { name: 'Envelope', operator: 'Include', values: ['*'] }
-          ]
-        }
-      ]
-    }
     autoMitigate: false
-    actions: { actionGroups: [actionGroup.id] }
+    dimensions: [
+      {
+        name: 'Envelope'
+        operator: 'Include'
+        values: ['*']
+      }
+    ]
+    tags: tags
   }
 }

--- a/infra/vendor/Azd.AzureMonitorNotifications/logic-app-action-group.bicep
+++ b/infra/vendor/Azd.AzureMonitorNotifications/logic-app-action-group.bicep
@@ -1,0 +1,43 @@
+@description('Name of the Azure Monitor action group.')
+@minLength(1)
+param actionGroupName string
+
+@description('Action group short name. Azure Monitor limits this value to 12 characters.')
+@minLength(1)
+@maxLength(12)
+param groupShortName string
+
+@description('Resource ID of the solution-owned Logic App workflow.')
+@minLength(1)
+param logicAppResourceId string
+
+@description('Display name of the Logic App receiver in the action group.')
+@minLength(1)
+param receiverName string
+
+@description('Name of the HTTP request trigger in the solution-owned Logic App workflow.')
+@minLength(1)
+param logicAppTriggerName string = 'manual'
+
+@description('Resource tags applied to the action group.')
+param tags object = {}
+
+resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
+  name: actionGroupName
+  location: 'Global'
+  tags: tags
+  properties: {
+    groupShortName: groupShortName
+    enabled: true
+    logicAppReceivers: [
+      {
+        name: receiverName
+        resourceId: logicAppResourceId
+        callbackUrl: listCallbackUrl('${logicAppResourceId}/triggers/${logicAppTriggerName}', '2019-05-01').value
+        useCommonAlertSchema: true
+      }
+    ]
+  }
+}
+
+output actionGroupResourceId string = actionGroup.id

--- a/infra/vendor/Azd.AzureMonitorNotifications/scheduled-query-alert.bicep
+++ b/infra/vendor/Azd.AzureMonitorNotifications/scheduled-query-alert.bicep
@@ -1,0 +1,94 @@
+@description('Name of the Azure Monitor scheduled-query rule.')
+@minLength(1)
+param alertRuleName string
+
+@description('Azure region of the target Log Analytics workspace.')
+@minLength(1)
+param location string
+
+@description('Resource ID of the target Log Analytics workspace.')
+@minLength(1)
+param workspaceResourceId string
+
+@description('Resource ID of the action group invoked when the rule fires.')
+@minLength(1)
+param actionGroupResourceId string
+
+@description('Display name shown for the scheduled-query rule.')
+@minLength(1)
+param displayName string
+
+@description('Solution-owned description of the alert behavior.')
+@minLength(1)
+param alertDescription string
+
+@description('Solution-owned KQL query evaluated by the rule.')
+@minLength(1)
+param query string
+
+@description('Alert severity from 0 (critical) through 4 (verbose).')
+@minValue(0)
+@maxValue(4)
+param severity int = 2
+
+@description('ISO 8601 interval controlling how often the query is evaluated.')
+@allowed([
+  'PT5M'
+])
+param evaluationFrequency string = 'PT5M'
+
+@description('ISO 8601 interval controlling the query lookback window.')
+@allowed([
+  'PT5M'
+  'PT10M'
+])
+param windowSize string = 'PT5M'
+
+@description('Whether Azure Monitor automatically resolves a fired alert after the condition clears.')
+param autoMitigate bool
+
+@description('Solution-owned dimensions emitted by the query and used to split alert instances.')
+param dimensions array = []
+
+@description('Resource tags applied to the scheduled-query rule.')
+param tags object = {}
+
+resource alert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
+  name: alertRuleName
+  location: location
+  tags: tags
+  properties: {
+    displayName: displayName
+    description: alertDescription
+    severity: severity
+    enabled: true
+    evaluationFrequency: evaluationFrequency
+    windowSize: windowSize
+    scopes: [
+      workspaceResourceId
+    ]
+    criteria: {
+      allOf: [
+        {
+          query: query
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+          failingPeriods: {
+            numberOfEvaluationPeriods: 1
+            minFailingPeriodsToAlert: 1
+          }
+          dimensions: dimensions
+        }
+      ]
+    }
+    autoMitigate: autoMitigate
+    actions: {
+      actionGroups: [
+        actionGroupResourceId
+      ]
+    }
+  }
+}
+
+output alertRuleResourceId string = alert.id

--- a/tests/Governance.Tests.ps1
+++ b/tests/Governance.Tests.ps1
@@ -17,4 +17,23 @@ Describe 'Component governance baseline' {
 
         { $invalidJson | Test-Json -SchemaFile $schemaPath -ErrorAction Stop } | Should -Throw
     }
+
+    It 'pins the Azure Monitor notification pilot to its reviewed release and exact vendored bytes' {
+        $lock = Get-Content -LiteralPath $lockPath -Raw | ConvertFrom-Json -AsHashtable
+        $component = @($lock.components | Where-Object { $_.id -eq 'azure-monitor-scheduled-query-notifications' })
+
+        $component.Count | Should -Be 1
+        $component[0].version | Should -Be '0.1.0'
+        $component[0].sourceRepository | Should -Be 'https://github.com/nathanmcnulty/azd-reference'
+        $component[0].sourceRevision | Should -Be '3424613b6b1ba38a1af60c2ab9bea9ef973c5bed'
+        @($component[0].files.target) | Should -Be @(
+            'infra/vendor/Azd.AzureMonitorNotifications/logic-app-action-group.bicep',
+            'infra/vendor/Azd.AzureMonitorNotifications/scheduled-query-alert.bicep'
+        )
+
+        foreach ($file in $component[0].files) {
+            $actual = (Get-FileHash -LiteralPath (Join-Path $repositoryRoot $file.target) -Algorithm SHA256).Hash.ToLowerInvariant()
+            $actual | Should -Be $file.sha256
+        }
+    }
 }

--- a/tests/Notifications.Tests.ps1
+++ b/tests/Notifications.Tests.ps1
@@ -38,3 +38,51 @@ Describe 'Guided Teams API connection' {
         $module | Should -Match 'URL is intentionally not printed'
     }
 }
+
+Describe 'Azure Monitor scheduled-query notification boundary' {
+    BeforeAll {
+        $script:logAnalyticsNotifications = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../infra/modules/log-analytics-notifications.bicep') -Raw
+        $script:actionGroupModule = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../infra/vendor/Azd.AzureMonitorNotifications/logic-app-action-group.bicep') -Raw
+        $script:scheduledQueryAlertModule = Get-Content -LiteralPath (Join-Path $PSScriptRoot '../infra/vendor/Azd.AzureMonitorNotifications/scheduled-query-alert.bicep') -Raw
+    }
+
+    It 'delegates only the reviewed Azure Monitor resources to the vendored pilot modules' {
+        $script:logAnalyticsNotifications | Should -Match "module actionGroup '../vendor/Azd\.AzureMonitorNotifications/logic-app-action-group\.bicep'"
+        $script:logAnalyticsNotifications | Should -Match "module alert '../vendor/Azd\.AzureMonitorNotifications/scheduled-query-alert\.bicep'"
+        $script:logAnalyticsNotifications | Should -Not -Match "resource actionGroup 'Microsoft\.Insights/actionGroups@"
+        $script:logAnalyticsNotifications | Should -Not -Match "resource alert 'Microsoft\.Insights/scheduledQueryRules@"
+    }
+
+    It 'preserves the risk-specific notification contract and resource dependencies' {
+        $script:logAnalyticsNotifications | Should -Match "actionGroupName: 'risk-la-\$\{suffix\}'"
+        $script:logAnalyticsNotifications | Should -Match "groupShortName: 'Entra risk'"
+        $script:logAnalyticsNotifications | Should -Match 'logicAppResourceId: workflow\.id'
+        $script:logAnalyticsNotifications | Should -Match "receiverName: 'Risk notification workflow'"
+        $script:logAnalyticsNotifications | Should -Match "alertRuleName: 'entra-risk-\$\{suffix\}'"
+        $script:logAnalyticsNotifications | Should -Match 'workspaceResourceId: workspaceResourceId'
+        $script:logAnalyticsNotifications | Should -Match 'actionGroupResourceId: actionGroup\.outputs\.actionGroupResourceId'
+        $script:logAnalyticsNotifications | Should -Match "displayName: 'Microsoft Entra risk detection'"
+        $script:logAnalyticsNotifications | Should -Match "alertDescription: 'Uses existing RiskyUsers and UserRiskEvents logs; does not create a workspace or require Sentinel\.'"
+        $script:logAnalyticsNotifications | Should -Match "evaluationFrequency: 'PT5M'"
+        $script:logAnalyticsNotifications | Should -Match "windowSize: 'PT10M'"
+        $script:logAnalyticsNotifications | Should -Match 'autoMitigate: false'
+        $script:logAnalyticsNotifications | Should -Match "name: 'Envelope'"
+        $script:logAnalyticsNotifications | Should -Match "operator: 'Include'"
+        $script:logAnalyticsNotifications | Should -Match "values: \['\*'\]"
+        $script:logAnalyticsNotifications | Should -Match 'query: riskQuery'
+        $script:logAnalyticsNotifications | Should -Match 'tags: tags'
+    }
+
+    It 'keeps the shared resources at the existing API versions and Azure Monitor semantics' {
+        $script:actionGroupModule | Should -Match "Microsoft\.Insights/actionGroups@2023-01-01"
+        $script:actionGroupModule | Should -Match "logicAppTriggerName string = 'manual'"
+        $script:actionGroupModule | Should -Match 'useCommonAlertSchema: true'
+        $script:scheduledQueryAlertModule | Should -Match "Microsoft\.Insights/scheduledQueryRules@2023-12-01"
+        $script:scheduledQueryAlertModule | Should -Match "timeAggregation: 'Count'"
+        $script:scheduledQueryAlertModule | Should -Match "operator: 'GreaterThan'"
+        $script:scheduledQueryAlertModule | Should -Match 'threshold: 0'
+        $script:scheduledQueryAlertModule | Should -Match 'numberOfEvaluationPeriods: 1'
+        $script:scheduledQueryAlertModule | Should -Match 'minFailingPeriodsToAlert: 1'
+        $script:scheduledQueryAlertModule | Should -Match 'enabled: true'
+    }
+}


### PR DESCRIPTION
## Summary

- vendor zure-monitor-scheduled-query-notifications@0.1.0 from protected reference tag
- refactor only the existing action-group and scheduled-query resources to canonical modules
- preserve Risk-owned KQL, Logic App workflow, storage, runtime, names, tags, dimensions, PT5M/PT10M cadence, and utoMitigate: false`n
## Validation

- 96/96 full Pester tests and 11/11 focused tests
- PowerShell/parser/analyzer, JSON/schema, Node tests/audit, component drift, and Bicep 0.46.1 build
- independent semantic/provenance review: no findings
- disposable commercial-lab baseline deployment succeeded
- adoption what-if was byte-for-byte equivalent to baseline self-what-if: no create/delete/replace; scheduled-query rule NoChange; action-group callback difference was the same listCallbackUrl evaluation noise in both
- adoption deployment succeeded and live safe properties retained exact resource IDs/names, common schema, PT5M/PT10M, Envelope dimension, and utoMitigate: false`n
## Release posture

The shared component remains pilot. Stable promotion still requires real Risk alert delivery evidence in addition to the existing deployment proof. Disposable proof resource group deletion was initiated after validation.